### PR TITLE
Reorder projects, rename Watershed, add renovating badge, archive AI CAD

### DIFF
--- a/components/project-list-item.js
+++ b/components/project-list-item.js
@@ -135,7 +135,7 @@ const ProjectListItem = ({
         >
           {badges &&
             badges
-              .filter((b) => b !== 'In Progress')
+              .filter((b) => b !== 'In Progress' && b !== 'Renovating')
               .slice(0, 3)
               .map((badge, i) => (
                 <Badge
@@ -197,6 +197,25 @@ const ProjectListItem = ({
               letterSpacing="0.02em"
             >
               in progress
+            </Badge>
+          )}
+
+          {badges && badges.includes('Renovating') && (
+            <Badge
+              bg="transparent"
+              border="1px solid"
+              borderColor="pine.400"
+              color={useColorModeValue('pine.500', 'pine.300')}
+              fontSize="0.65em"
+              fontWeight="500"
+              fontFamily="body"
+              textTransform="lowercase"
+              px={2}
+              py={0.5}
+              borderRadius="4px"
+              letterSpacing="0.02em"
+            >
+              renovating
             </Badge>
           )}
 
@@ -262,7 +281,7 @@ const ProjectListItem = ({
               <Stack direction="row" spacing={2} wrap="wrap">
                 {badges &&
                   badges
-                    .filter((b) => b !== 'In Progress')
+                    .filter((b) => b !== 'In Progress' && b !== 'Renovating')
                     .map((badge, i) => (
                       <Badge
                         key={i}

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -38,12 +38,12 @@ const projectList = [
   },
   {
     id: 'watershed-ai',
-    title: 'Multi System AI Agent',
+    title: 'Watershed VC AI System',
     description:
-      'Automated venture capital research and data enrichment system using multi-agent AI architecture. Agents coordinate to scrape, enrich, and score startup data across multiple sources.',
+      'Full-scale AI agent system built for a VC firm that automates research, company evaluation, investment memo drafting, and daily partner workflows. Tracks early-stage and stealth company developments, enriches deal flow data, and surfaces insights across the entire pipeline.',
     thumbnail: watershed,
-    badges: ['Agentic AI', 'Python', 'Supabase', 'AWS'],
-    year: '2025',
+    badges: ['Agentic AI', 'Python', 'Supabase', 'AWS', 'Next.js'],
+    year: '2025-26',
     archived: false,
   },
   {
@@ -87,16 +87,6 @@ const projectList = [
     archived: false,
   },
   {
-    id: 'AI-CAD',
-    title: 'AI CAD Project Builder',
-    description:
-      'Generate CAD models from text prompts using AI. Built with Hugging Face models to translate natural language descriptions into 3D-printable designs.',
-    thumbnail: CAD,
-    badges: ['AI', 'Hugging Face', 'Python'],
-    year: '2025',
-    archived: false,
-  },
-  {
     id: 'techlead',
     title: 'EWB Tech Group Lead',
     description:
@@ -128,6 +118,16 @@ const projectList = [
     archived: false,
   },
   {
+    id: 'calendar',
+    title: 'Calendar Connect',
+    description:
+      'Compare academic calendars across universities to help plan visits and coordinate schedules. Originally built in 2024, currently being reworked from the ground up.',
+    thumbnail: calendars,
+    badges: ['React', 'Full-Stack', 'Renovating'],
+    year: '2024 / 26',
+    archived: false,
+  },
+  {
     id: 'cplus',
     title: 'C++ Projects',
     description:
@@ -138,12 +138,12 @@ const projectList = [
     archived: true,
   },
   {
-    id: 'calendar',
-    title: 'Calendar Connect',
+    id: 'AI-CAD',
+    title: 'AI CAD Project Builder',
     description:
-      'A website designed to help users compare academic calendars across universities, making it easier to plan visits and coordinate schedules.',
-    thumbnail: calendars,
-    badges: ['React', 'Full-Stack'],
+      'Generate CAD models from text prompts using AI. Built with Hugging Face models to translate natural language descriptions into 3D-printable designs.',
+    thumbnail: CAD,
+    badges: ['AI', 'Hugging Face', 'Python'],
     year: '2024',
     archived: true,
   },

--- a/pages/projects/watershed-ai.js
+++ b/pages/projects/watershed-ai.js
@@ -12,65 +12,56 @@ import P from '../../components/paragraph'
 import Layout from '../../components/layouts/article'
 
 const Work = () => (
-  <Layout title="Multi System AI Agent">
+  <Layout title="Watershed VC AI System">
     <Container pt={6}>
       <Title>
-        Multi-Agent AI System<Badge>2025</Badge>
+        Watershed VC AI System<Badge>2025-26</Badge>
       </Title>
       <P>
-        I created a multi-agent AI system that automated Watershed Ventures' venture capital research and data enrichment process. 
-        The system streamlined sourcing, evaluating, and maintaining structured information on startups and investors, providing analysts 
-        with reliable, real-time data.
+        Built a complete AI agent system for Watershed Ventures that handles nearly every part of a VC partner's
+        daily workflow. The system automates research, company and people evaluation, investment memo drafting,
+        deal flow tracking, and monitoring of early-stage and stealth company developments as they happen.
       </P>
 
       <Heading as="h3" variant="section-title" mt={6} mb={4}>
-        Key Contributions
+        What It Does
       </Heading>
-      
+
       <Box mb={4}>
-        <Text fontWeight="bold" mb={2}>Agent Architecture:</Text>
-        <Text>Designed specialized agents for company retrieval, data enrichment, and database management, coordinated through a central orchestrator.</Text>
+        <Text fontWeight="bold" mb={2}>Research + Evaluation</Text>
+        <Text>Agents independently source, enrich, and score companies and founders across data providers, accelerators, and early-stage funds. Cross-references funding history, headcount trends, LinkedIn profiles, and more to build a full picture fast.</Text>
       </Box>
 
       <Box mb={4}>
-        <Text fontWeight="bold" mb={2}>API Integrations:</Text>
-        <Text>Connected to major data providers to automatically pull and cross-reference startup and investor data.</Text>
+        <Text fontWeight="bold" mb={2}>Memo Drafting</Text>
+        <Text>Generates structured investment memos from enriched data, saving partners hours of manual writing while keeping the output grounded in real data points.</Text>
       </Box>
 
       <Box mb={4}>
-        <Text fontWeight="bold" mb={2}>Database Engineering:</Text>
-        <Text>Built a Supabase/Postgres schema for company_profiles and people, with JSONB fields for founders and SQL triggers for automatic indexing and search.</Text>
+        <Text fontWeight="bold" mb={2}>Stealth + Early-Stage Tracking</Text>
+        <Text>Monitors rapid developments and changes at stealth and pre-seed companies that traditional tools miss. Surfaces signals before they hit the mainstream deal flow.</Text>
       </Box>
 
       <Box mb={4}>
-        <Text fontWeight="bold" mb={2}>Automated Pipelines:</Text>
-        <Text>Implemented workflows for importing CSVs, enriching missing fields (funding history, headcount, LinkedIn profiles), and updating investor portfolios.</Text>
+        <Text fontWeight="bold" mb={2}>Daily Partner Workflows</Text>
+        <Text>Handles CSV imports, database updates, portfolio monitoring, and recurring data hygiene tasks. Partners interact through an internal platform to view results, filter companies and people, and manually adjust when needed.</Text>
       </Box>
 
       <Box mb={4}>
-        <Text fontWeight="bold" mb={2}>LLM-Driven Reasoning:</Text>
-        <Text>Used Google Gemini to enable agents to make context-aware decisions on when to query APIs, update records, or escalate incomplete information.</Text>
+        <Text fontWeight="bold" mb={2}>Agent Architecture</Text>
+        <Text>Specialized agents for company retrieval, data enrichment, memo generation, and database management, all coordinated through a central orchestrator. LLM-driven reasoning (Google Gemini) lets agents decide when to query APIs, update records, or flag incomplete information.</Text>
       </Box>
 
       <Heading as="h3" variant="section-title" mt={6} mb={4}>
         Impact
       </Heading>
-      
+
       <List spacing={2} mb={4}>
         <ListItem>• Cut manual research and data entry time by over 50%</ListItem>
-        <ListItem>• Provided Watershed with an always up-to-date view of emerging startups across accelerators and early-stage funds</ListItem>
-        <ListItem>• Built the foundation for autonomous deal-sourcing workflows that improve speed and accuracy in venture research</ListItem>
-        <ListItem>• Created an internal platform for interacting with the agent, viewing results, manually updating data if needed, filtering and viewing companies and people</ListItem>
+        <ListItem>• Always up-to-date view of emerging startups, stealth companies, and fund activity</ListItem>
+        <ListItem>• Foundation for autonomous deal-sourcing workflows that keep getting better over time</ListItem>
+        <ListItem>• Internal platform used daily by the team to interact with the system</ListItem>
       </List>
-
-      <Heading as="h3" variant="section-title" mt={6} mb={4}>
-        Takeaways
-      </Heading>
-      
-      <P>
-        This project strengthened my experience in multi-agent AI systems, database design, and API-driven automation, 
-        and showed me how to align cutting-edge AI with practical business workflows in venture capital.
-      </P>
 
       <List ml={4} my={4}>
         <ListItem>
@@ -87,7 +78,7 @@ const Work = () => (
         </ListItem>
         <ListItem>
           <Meta>Stack</Meta>
-          <span>Python, Google Gemini, Supabase/Postgres, React, APIs</span>
+          <span>Python, Google Gemini, Supabase/Postgres, AWS, Next.js</span>
         </ListItem>
         <ListItem>
           <Meta>Key Technologies</Meta>


### PR DESCRIPTION
- Move AI CAD to archived (year 2024)
- Move Calendar Connect back to recent with "renovating" badge (2024 / 26)
- Rename Watershed project to "Watershed VC AI System" (2025-26)
- Rewrite Watershed description and detail page to cover the full scope: research, evaluation, memo drafting, stealth tracking, daily workflows
- Add AWS and Next.js to Watershed tags
- Add "renovating" status badge support to project list item component

https://claude.ai/code/session_01JMUaSFWBbhnKY89Dbnt6z7